### PR TITLE
Fix absolute path on imports

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -108,8 +108,7 @@ func goGet(gitURL string, update bool) (err error) {
 }
 
 func goBuild(gitURL, filename string) (err error) {
-	goDir := getGoDir(gitURL)
-	gobuild := exec.Command("go", "build", "--buildmode", "plugin", "-o", filename, goDir)
+	gobuild := exec.Command("go", "build", "--buildmode", "plugin", "-o", filename, gitURL)
 	gobuild.Stdin = os.Stdin
 	gobuild.Stdout = os.Stdout
 	gobuild.Stderr = os.Stderr


### PR DESCRIPTION
VPM update/build were getting errors due to getGoDir returning an absolute file path. 

```
ERRO[0000] error building plugins: can't load package: package /Users/user/go/src/github.com/company/repo/service/plugin: cannot import absolute path 
```

Updated to just use GitHub dir, though this may not support non GitHub repos? It seems to work for my repository