### PR TITLE
Enable parsing of @vX.X.X semver tags in vroomy configs

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -83,6 +83,7 @@ func (p *Plugin) updatePlugin() (err error) {
 				return
 			}
 
+			p.out.Notificationf("Updated to version: %s", p.branch)
 			return p.updateDependencies()
 		}
 	}
@@ -91,22 +92,25 @@ func (p *Plugin) updatePlugin() (err error) {
 	var status string
 	if status, err = gitPull(p.gitURL); len(status) == 0 || err != nil {
 		if err == nil {
-			p.out.Success("Already up to date!")
+			p.out.Notification("Already up to date!")
 		}
+	} else {
+		p.out.Notification("Updated to latest ref.")
 	}
 
-	p.out.Notification("Updated plugin source.")
 	return p.updateDependencies()
 }
 
 func (p *Plugin) checkout() (err error) {
-	p.out.Notificationf("Checking out %s...", p.branch)
+	p.out.Notificationf("Updating %s...", p.branch)
 
 	var status string
 	if status, err = gitCheckout(p.gitURL, p.branch); err != nil {
 		return
 	} else if len(status) != 0 {
 		p.out.Notificationf("Switched to \"%s\" branch", p.branch)
+	} else {
+		p.out.Notificationf("Already on \"%s\" branch", p.branch)
 	}
 
 	return

--- a/plugins.go
+++ b/plugins.go
@@ -81,11 +81,7 @@ func (p *Plugins) Retrieve() (err error) {
 	defer p.mu.Unlock()
 
 	for _, pi := range p.ps {
-		if err = pi.checkout(); err != nil {
-			return
-		}
-
-		if err = pi.retrieve(); err != nil {
+		if err = pi.updatePlugin(); err != nil {
 			return
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -27,6 +27,24 @@ func parseKey(key string) (newKey, alias string) {
 	return
 }
 
+func gitFetch(gitURL string) (err error) {
+	gitfetch := exec.Command("git", "fetch", ";", "git", "fetch", "--tags", "--force")
+	gitfetch.Dir = getGitDir(gitURL)
+	gitfetch.Stdin = os.Stdin
+
+	outBuf := bytes.NewBuffer(nil)
+	gitfetch.Stdout = outBuf
+
+	errBuf := bytes.NewBuffer(nil)
+	gitfetch.Stderr = errBuf
+
+	if err = gitfetch.Run(); err == nil && errBuf.Len() == 0 {
+		return
+	}
+
+	return
+}
+
 func gitCheckout(gitURL, branch string) (resp string, err error) {
 	gitcheckout := exec.Command("git", "checkout", branch)
 	gitcheckout.Dir = getGitDir(gitURL)

--- a/utils.go
+++ b/utils.go
@@ -226,15 +226,28 @@ func getGitPluginKey(gitURL string) (key, branch string, err error) {
 }
 
 func getGitURLParts(gitURL string) (gitUser, repoName, branch string, err error) {
+	// Attempt to parse version first
+	comps := strings.Split(gitURL, "@")
+
+	// Parse url/branch
 	var u *url.URL
-	if u, err = url.Parse("http://" + gitURL); err != nil {
+	if u, err = url.Parse("http://" + comps[0]); err != nil {
 		return
 	}
 
+	// Split parts
 	parts := stripEmpty(strings.Split(u.Path, "/"))
 	gitUser = parts[0]
 	repoName = parts[1]
-	branch = u.Fragment
+
+	if len(comps) > 1 {
+		// Optional Version
+		branch = comps[1]
+	} else {
+		// Optional Branch
+		branch = u.Fragment
+	}
+
 	return
 }
 
@@ -340,6 +353,7 @@ func isDoesNotExistError(err error) (ok bool) {
 
 func removeBranchHash(gitURL string) (out string) {
 	spl := strings.Split(gitURL, "#")
+	spl = strings.Split(spl[0], "@")
 	out = spl[0]
 	return
 }

--- a/utils.go
+++ b/utils.go
@@ -27,8 +27,8 @@ func parseKey(key string) (newKey, alias string) {
 	return
 }
 
-func gitFetch(gitURL string) (err error) {
-	gitfetch := exec.Command("git", "fetch", ";", "git", "fetch", "--tags", "--force")
+func gitFetchTags(gitURL string) (err error) {
+	gitfetch := exec.Command("git", "fetch", "--tags", "--force")
 	gitfetch.Dir = getGitDir(gitURL)
 	gitfetch.Stdin = os.Stdin
 


### PR DESCRIPTION
Retains previous functionality.

Handles individual cases of:
1) no branch specified (latest current, pull deps)
2) \# branch specified (switch and notify, then update to latest, pull deps)
3) @ version specified (check out and pull deps)